### PR TITLE
Field name in error

### DIFF
--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -58,9 +58,8 @@ struct MaybeIdent(Option<syn::Ident>);
 
 impl quote::ToTokens for MaybeIdent {
   fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-    tokens.append(proc_macro2::Ident::new(
-      format!("{}", self).as_str(),
-      proc_macro2::Span::call_site()
+    tokens.append(proc_macro2::Literal::string(
+      format!("{}", self).as_str()
     ));
   }
 }

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -111,7 +111,7 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
               match row_group_writer.close_column(column_writer) {
                 Ok(res) => res,
                 Err(err) => {
-                  panic!("error writing {}: {}", #field_names, err);
+                  panic!("{}: {}", #field_names, err);
                 }
               };
           }

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -50,6 +50,30 @@ mod parquet_field;
 /// }
 /// ```
 ///
+
+use quote::TokenStreamExt;
+
+// Newtype for Option<syn::Ident>
+struct MaybeIdent(Option<syn::Ident>);
+
+impl quote::ToTokens for MaybeIdent {
+  fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+    tokens.append(proc_macro2::Ident::new(
+      format!("{}", self).as_str(),
+      proc_macro2::Span::call_site()
+    ));
+  }
+}
+
+impl std::fmt::Display for MaybeIdent {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    match &self.0 {
+      Some(ident) => write!(f, "{}", ident),
+      None => write!(f, "")
+    }
+  }
+}
+
 #[proc_macro_derive(ParquetRecordWriter)]
 pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input: DeriveInput = parse_macro_input!(input as DeriveInput);
@@ -58,6 +82,11 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
         Data::Enum(_) => unimplemented!("don't support enum"),
         Data::Union(_) => unimplemented!("don't support union"),
     };
+
+    let field_names: Vec<_> = fields
+      .iter()
+      .map(|f: &syn::Field| MaybeIdent(f.ident.clone()))
+      .collect();
 
     let field_infos: Vec<_> = fields
         .iter()
@@ -80,7 +109,12 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
           {
               let mut column_writer = row_group_writer.next_column().unwrap().unwrap();
               #writer_snippets
-              row_group_writer.close_column(column_writer).unwrap();
+              match row_group_writer.close_column(column_writer) {
+                Ok(res) => res,
+                Err(err) => {
+                  panic!("error writing {}: {}", #field_names, err);
+                }
+              };
           }
         );*
       }


### PR DESCRIPTION
If there's an error writing a column, this includes the column name in the output to help with debugging

```
thread 'main' panicked at '**src_node**: Parquet error: Incorrect number of rows, expected 9999 != 9978 rows', source.rs:12:46
```